### PR TITLE
Bump file_picker from 10.3.10 to 11.0.2 and fix breaking API

### DIFF
--- a/lib/service/user.dart
+++ b/lib/service/user.dart
@@ -35,7 +35,7 @@ class UserService {
   }
 
   Future<void> uploadAvatar() async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles();
+    FilePickerResult? result = await FilePicker.pickFiles();
 
     if (result != null) {
       var bytes = result.files.first.bytes;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -261,10 +261,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.2"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   built_collection: 5.1.1
   flutter_localization: 0.4.0
   intl: 0.20.2
-  file_picker: 10.3.10
+  file_picker: 11.0.2
   package_info_plus: 9.0.1
   flutter_blurhash: 0.9.1
   time_machine: 0.9.17


### PR DESCRIPTION
Updates file_picker to v11.0.2 (rebased onto main) and migrates the
call site from the removed instance-based FilePicker.platform.pickFiles()
to the new static FilePicker.pickFiles() introduced in v11.0.0.

https://claude.ai/code/session_01HAgmgrwBtVDacqx3HV36nt